### PR TITLE
feat: make sysadmin dashboard org aware and implement course access r…

### DIFF
--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -10,7 +10,7 @@ import urllib.parse
 
 import requests
 from common.djangoapps.student.models import UserProfile
-from common.djangoapps.student.roles import CourseInstructorRole
+from common.djangoapps.student.roles import OrgInstructorRole, OrgStaffRole
 from common.djangoapps.util.password_policy_validators import normalize_password
 from django import forms
 from django.conf import settings
@@ -20,9 +20,8 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django_countries import countries
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
-from openedx.core.djangoapps.user_authn.toggles import (
-    is_require_third_party_auth_enabled,
-)
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_authn.toggles import is_require_third_party_auth_enabled
 from xmodule.modulestore.django import modulestore
 
 from edx_sysadmin.models import CourseGitLog
@@ -366,15 +365,45 @@ def show_sysadmin_dashboard(user):
     return user_has_access_to_sysadmin(user)
 
 
+def user_has_staff_org_role(user):
+    """
+    Checks if user has the staff role associated with the current organization.
+    :param user: User object of currently loggedin user
+    :return boolean: True if user has the role else False
+    """
+    orgs = configuration_helpers.get_current_site_orgs()
+
+    if orgs:
+        for org in orgs:
+            if OrgStaffRole(org=org).has_user(user):
+                return True
+
+    return user.is_staff
+
+
+def user_has_instructor_org_role(user):
+    """
+    Checks if user has the instructor role associated with the current organization.
+    :param user: User object of currently loggedin user
+    :return boolean: True if user has the role else False
+    """
+    orgs = configuration_helpers.get_current_site_orgs()
+
+    if orgs:
+        for org in orgs:
+            if OrgInstructorRole(org=org).has_user(user):
+                return True
+
+    return False
+
+
 def user_has_access_to_users_panel(user):
     """
     Check if user has access to "Users" panel or not
     :param user: User object of currently loggedin user
     :return boolean: True if user has access to "Users" panel else False
     """
-    if user and user.is_staff:  # noqa: SIM103
-        return True
-    return False
+    return user_has_staff_org_role(user)
 
 
 def user_has_access_to_courses_panel(user):
@@ -383,9 +412,7 @@ def user_has_access_to_courses_panel(user):
     :param user: User object of currently loggedin user
     :return boolean: True if user has access to "Courses" panel else False
     """
-    if user and user.is_staff:  # noqa: SIM103
-        return True
-    return False
+    return user_has_staff_org_role(user)
 
 
 def user_has_access_to_git_logs_panel(user):
@@ -394,9 +421,9 @@ def user_has_access_to_git_logs_panel(user):
     :param user: User object of currently loggedin user
     :return boolean: True if user has access to "Git Logs" panel else False
     """
-    if user and (  # noqa: SIM103
-        user.is_staff
-        or user.courseaccessrole_set.filter(role=CourseInstructorRole.ROLE).exists()
+    if user and (
+        user_has_staff_org_role(user)
+        or user_has_instructor_org_role(user)
     ):
         return True
     return False
@@ -408,9 +435,7 @@ def user_has_access_to_git_import_panel(user):
     :param user: User object of currently loggedin user
     :return boolean: True if user has access to "Git Import" panel else False
     """
-    if user and user.is_staff:  # noqa: SIM103
-        return True
-    return False
+    return user_has_staff_org_role(user)
 
 
 def remove_old_course_import_logs(course_id):

--- a/edx_sysadmin/views.py
+++ b/edx_sysadmin/views.py
@@ -19,6 +19,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import condition
 from django.views.generic.base import RedirectView, TemplateView
+from lms.djangoapps.branding import get_visible_courses
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.django import modulestore
@@ -119,8 +120,7 @@ class CoursesPanel(SysadminDashboardBaseView):
 
     def get_course_summaries(self):
         """Get an iterable list of course summaries."""
-
-        return modulestore().get_course_summaries()
+        return get_visible_courses()
 
     def make_datatable(self, courses=None):
         """Create course information datatable"""


### PR DESCRIPTION
## Description

This update includes the following changes:

1. Make the sysadmin panel tenant-aware (courses are now displayed based on the `course_org_filter` value).
2. Allow access to the sysadmin panel based on the user's course access role.

Migration pr of https://github.com/nelc/edx-sysadmin/pull/3

Issue # [1296](https://edunext.atlassian.net/browse/FUTUREX-1296)

## How to test
1. Set the course_org_filter with the right organization
2. Set the course access role for a non admin user
![image](https://github.com/user-attachments/assets/97736d01-cb4f-4fd8-a87f-6e82125cda29)
3. Go to /sysadmin and check the courses sections with and admin user a non admin user

### Before
<img width="1785" height="1009" alt="image" src="https://github.com/user-attachments/assets/e7e9d63c-b3a5-45a6-858c-b77c6c0a3b22" />


### After
<img width="1724" height="989" alt="image" src="https://github.com/user-attachments/assets/d67b7d2e-f459-492c-a480-161b04d43ba9" />
